### PR TITLE
fix: error TS6133: 'Outlet' is declared but its value is never

### DIFF
--- a/src/pages/PageLayout.tsx
+++ b/src/pages/PageLayout.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Outlet } from "react-router-dom";
 import { useRef } from "react";
 import NavBar from "../components/NavBar";
 import SideBar from "../components/SideBar";


### PR DESCRIPTION
Prod build failed due to the error